### PR TITLE
remove useless width

### DIFF
--- a/style.css
+++ b/style.css
@@ -629,7 +629,6 @@ p[id] {
 }
 
 .psg-title {
-  width: 100%;
   padding: 40px 60px;
   font-size: 2rem;
   text-align: center;


### PR DESCRIPTION
The default width is equal to parent's width.
There is a extra scrollbar when setting `width: 100%`.
example: https://jsbin.com/cicahe/1/edit?html,output
screenshot: http://imgur.com/WXSdLyC

![image](https://cloud.githubusercontent.com/assets/1808835/16168590/47ab2860-353f-11e6-9b04-b47ec6113b13.png)
